### PR TITLE
Generalize the Convolution Depth of Encoders

### DIFF
--- a/atariari/methods/global_local_infonce.py
+++ b/atariari/methods/global_local_infonce.py
@@ -35,9 +35,9 @@ class GlobalLocalInfoNCESpatioTemporalTrainer(Trainer):
         self.device = device
         if self.use_multiple_predictors:
             # todo remove the hard coded 11x8
-            self.classifiers = [nn.Linear(self.encoder.hidden_size, 128).to(device) for _ in range(11*8)]
+            self.classifiers = [nn.Linear(self.encoder.hidden_size, self.encoder.local_layer_depth).to(device) for _ in range(11*8)]
         else:
-            self.classifier1 = nn.Linear(self.encoder.hidden_size, 128).to(device)
+            self.classifier1 = nn.Linear(self.encoder.hidden_size, self.encoder.local_layer_depth).to(device)
         self.params = list(self.encoder.parameters())
         if self.use_multiple_predictors:
             for classifier in self.classifiers:

--- a/atariari/methods/jsd_stdim.py
+++ b/atariari/methods/jsd_stdim.py
@@ -27,8 +27,8 @@ class SpatioTemporalTrainer(Trainer):
         super().__init__(encoder, wandb, device)
         self.config = config
         self.patience = self.config["patience"]
-        self.classifier1 = Classifier(self.encoder.hidden_size, 128).to(device)
-        self.classifier2 = Classifier(128, 128).to(device)
+        self.classifier1 = Classifier(self.encoder.hidden_size, self.encoder.local_layer_depth).to(device)
+        self.classifier2 = Classifier(self.encoder.local_layer_depth, self.encoder.local_layer_depth).to(device)
         self.epochs = config['epochs']
         self.batch_size = config['batch_size']
         self.device = device

--- a/atariari/methods/stdim.py
+++ b/atariari/methods/stdim.py
@@ -28,8 +28,8 @@ class InfoNCESpatioTemporalTrainer(Trainer):
         super().__init__(encoder, wandb, device)
         self.config = config
         self.patience = self.config["patience"]
-        self.classifier1 = nn.Linear(self.encoder.hidden_size, 128).to(device)  # x1 = global, x2=patch, n_channels = 32
-        self.classifier2 = nn.Linear(128, 128).to(device)
+        self.classifier1 = nn.Linear(self.encoder.hidden_size, self.encoder.local_layer_depth).to(device)  # x1 = global, x2=patch, n_channels = 32
+        self.classifier2 = nn.Linear(self.encoder.local_layer_depth, self.encoder.local_layer_depth).to(device)
         self.epochs = config['epochs']
         self.batch_size = config['batch_size']
         self.device = device

--- a/atariari/methods/temporal_dim.py
+++ b/atariari/methods/temporal_dim.py
@@ -27,8 +27,8 @@ class SpatioTemporalTrainer(Trainer):
         super().__init__(encoder, wandb, device)
         self.config = config
         self.patience = self.config["patience"]
-        self.classifier1 = Classifier(self.encoder.hidden_size, 128).to(device)
-        self.classifier2 = Classifier(128, 128).to(device)
+        self.classifier1 = Classifier(self.encoder.hidden_size, self.encoder.local_layer_depth).to(device)
+        self.classifier2 = Classifier(self.encoder.local_layer_depth, self.encoder.local_layer_depth).to(device)
         self.epochs = config['epochs']
         self.batch_size = config['batch_size']
         self.device = device


### PR DESCRIPTION
My team's ablation study of this paper for the Neurips Reproducibility Challenge requires us to experiment with different encoder architectures, including the ImpalaCNN that was already added to the codebase. This change allows for flexibility in the depth of the convolutional layer of the encoder. I achieve this by:
1. Add a `local_layer_depth` property to each encoder
2. Modifying the various SpatioTemporal trainers to initialize their
classifiers using this property as opposed to the hardcoded 128.

Additionally, I also included the fmaps keyword argument to ImpalaCNN's `forward` method using the 3rd or 4th block (depending on whether we want to downsample or not) output as the convolutional layer for computing the global-local loss.

For the time being, my team is working from this repository https://github.com/GabrielAlacchi/atari-ari-extensions where we've extended some of these classes to achieve this behavior, however I figured I'd share this change with you as well if you're interested!
