### PR TITLE
Use uint8 When Loading Episodes to Save Memory

### DIFF
--- a/atariari/benchmark/episodes.py
+++ b/atariari/benchmark/episodes.py
@@ -49,11 +49,11 @@ def get_random_agent_rollouts(env_name, steps, seed=42, num_processes=1, num_fra
                 episode_rewards.append(info['episode']['r'])
 
             if done[i] != 1:
-                episodes[i][-1].append(obs[i].clone())
+                episodes[i][-1].append(obs[i].clone().type(torch.uint8))
                 if "labels" in info.keys():
                     episode_labels[i][-1].append(info["labels"])
             else:
-                episodes[i].append([obs[i].clone()])
+                episodes[i].append([obs[i].clone().type(torch.uint8)])
                 if "labels" in info.keys():
                     episode_labels[i].append([info["labels"]])
 
@@ -96,11 +96,11 @@ def get_ppo_rollouts(env_name, steps, seed=42, num_processes=1,
                 episode_rewards.append(info['episode']['r'])
 
             if done[i] != 1:
-                episodes[i][-1].append(obs[i].clone())
+                episodes[i][-1].append(obs[i].clone().type(torch.uint8))
                 if "labels" in info.keys():
                     episode_labels[i][-1].append(info["labels"])
             else:
-                episodes[i].append([obs[i].clone()])
+                episodes[i].append([obs[i].clone().type(torch.uint8)])
                 if "labels" in info.keys():
                     episode_labels[i].append([info["labels"]])
 


### PR DESCRIPTION
This PR modifies the `get_random_agent_rollouts` and `get_ppo_rollouts` methods by casting the images to `torch.uint8`. Doing this saves over 9GB of memory when training on the default 100,000 steps. During train and run time, dividing a batch of episodes by `255.` will automatically cast the type to float. For example:

```
>>> a = torch.from_numpy(np.ones((1, 210, 160), dtype=np.uint8))
>>> a
tensor([[[1, 1, 1,  ..., 1, 1, 1],
         [1, 1, 1,  ..., 1, 1, 1],
         [1, 1, 1,  ..., 1, 1, 1],
         ...,
         [1, 1, 1,  ..., 1, 1, 1],
         [1, 1, 1,  ..., 1, 1, 1],
         [1, 1, 1,  ..., 1, 1, 1]]], dtype=torch.uint8)
>>> a / 255.
tensor([[[0.0039, 0.0039, 0.0039,  ..., 0.0039, 0.0039, 0.0039],
         [0.0039, 0.0039, 0.0039,  ..., 0.0039, 0.0039, 0.0039],
         [0.0039, 0.0039, 0.0039,  ..., 0.0039, 0.0039, 0.0039],
         ...,
         [0.0039, 0.0039, 0.0039,  ..., 0.0039, 0.0039, 0.0039],
         [0.0039, 0.0039, 0.0039,  ..., 0.0039, 0.0039, 0.0039],
         [0.0039, 0.0039, 0.0039,  ..., 0.0039, 0.0039, 0.0039]]])
```

Therefore I'd argue strongly that there's no reason to convert the images to float32 until run-time as this requires 4x the memory.