### PR TITLE
Change private eye label names to be consistent

### DIFF
--- a/atariari/benchmark/ram_annotations.py
+++ b/atariari/benchmark/ram_annotations.py
@@ -184,8 +184,8 @@ atari_dict = {
                  enemy_score=13,
                  player_score=14),
 
-    "privateeye": dict(agent_x=63,
-                       agent_y=86,
+    "privateeye": dict(player_x=63,
+                       player_y=86,
                        room_number=92,
                        clock=[67, 69],
                        player_direction=58,


### PR DESCRIPTION
Weirdly enough privateeye used agent instead of player, but all other ones use player.
Also privateeye used player for direction, but not for x and y
This will help for any grouping/parsing