### PR TITLE
removed some inconsistencies in Yar's Revenge

### DIFF
--- a/atariari/benchmark/ram_annotations.py
+++ b/atariari/benchmark/ram_annotations.py
@@ -268,14 +268,14 @@ atari_dict = {
                          score_1=48,
                          score_2=50),
 
-    "yarsrevenge": dict(player_yar_x=32,
-                        player_yar_y=31,
-                        yar_missile_x=38,
-                        yar_missile_y=37,
-                        enemy_qotile_x=43,
-                        enemy_qotile_y=42,
-                        qotile_missile_x=47,
-                        qotile_missile_y=46)
+    "yarsrevenge": dict(player_x=32,
+                        player_y=31,
+                        player_missile_x=38,
+                        player_missile_y=37,
+                        enemy_x=43,
+                        enemy_y=42,
+                        enemy_missile_x=47,
+                        enemy_missile_y=46)
 }
 
 # break up any lists (e.g. dict(clock=[67, 69]) -> dict(clock_0=67, clock_1=69) )


### PR DESCRIPTION
It's unnecessary to specify player's name in the games unless the player has multiple identities, like the paddle in VideoPinball. Just player will do. Also when parsing by "_y" for finding coordinates, "player_yar" can confuse things
player_yar_x -> player_x
player_yar_y -> player_y

Also, same goes for enemies
enemy_quotile -> enemy
quotile -> enemy