### PR TITLE
Add tile colors and game score annotations for Qbert

### DIFF
--- a/atariari/benchmark/ram_annotations.py
+++ b/atariari/benchmark/ram_annotations.py
@@ -12,7 +12,7 @@ Game dictionary is organized as:
             in value correspondingly)
 """
 """ MZR player_direction values:
-         72:  facing left, 
+         72:  facing left,
          40:  facing left, climbing down ladder/rope
          24:  facing left, climbing up ladder/rope
          128: facing right
@@ -197,7 +197,14 @@ atari_dict = {
                   player_y=67,
                   player_column=35,
                   red_enemy_column=69,
-                  green_enemy_column=105),
+                  green_enemy_column=105,
+                  score=[89, 90, 91], # binary coded decimal score
+                  tile_color=[1, 3, 5, 7, 9,          # row of 5
+                              21, 32, 34, 36, 38, 40, # row of 6
+                              42,                     # row of 1
+                              52, 54,                 # row of 2
+                              83, 85, 87,             # row of 3
+                              98, 100, 102, 104]),    # row of 4
 
     "riverraid": dict(player_x=51,
                       missile_x=117,

--- a/atariari/benchmark/ram_annotations.py
+++ b/atariari/benchmark/ram_annotations.py
@@ -199,12 +199,12 @@ atari_dict = {
                   red_enemy_column=69,
                   green_enemy_column=105,
                   score=[89, 90, 91], # binary coded decimal score
-                  tile_color=[1, 3, 5, 7, 9,          # row of 5
-                              21, 32, 34, 36, 38, 40, # row of 6
-                              42,                     # row of 1
-                              52, 54,                 # row of 2
-                              83, 85, 87,             # row of 3
-                              98, 100, 102, 104]),    # row of 4
+                  tile_color=[         21,                # row of 1
+                                     52,  54,             # row of 2
+                                   83,  85,  87,          # row of 3
+                                 98, 100, 102, 104,       # row of 4
+                                1,  3,   5,   7,  9,      # row of 5
+                              32, 34, 36,  38,  40, 42]), # row of 6
 
     "riverraid": dict(player_x=51,
                       missile_x=117,


### PR DESCRIPTION
Adds tile color annotations to Qbert, since flipping the tile colors is the central objective of the game. Also adds score information, because the tile colors change in later levels, and eventually even require multiple flips. These additional annotations make the game much more playable from ARI features alone.