### PR TITLE
RAM annotation for Blue Ghosts in MsPacman

### DIFF
--- a/atariari/benchmark/ram_annotations.py
+++ b/atariari/benchmark/ram_annotations.py
@@ -160,6 +160,7 @@ atari_dict = {
                      fruit_y=17,
                      ghosts_count=19,
                      player_direction=56,
+                     ghosts_blue=116,
                      dots_eaten_count=119,
                      player_score=120,
                      num_lives=123),


### PR DESCRIPTION
(The following is my observation through trial and error. So it may not be 100% correct.)

In MsPacman, by default, ram[116] == 0. When MsPacman eats the Power Pellet, and the ghosts get blue, the lower 6 bits of ram[116] shows the remaining time, and the higher 2 bits show the number of the killed ghosts. For example, after two ghosts are killed, ram[116] == (remaining time) + 2 << 7.